### PR TITLE
ci: checkoutのfetch-depthの設定を削除

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
 
       - name: Setup | Node.js development environment
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.github/workflows/release-please.yml` file by removing the `fetch-depth` configuration from the `actions/checkout` step, simplifying the setup process.