### PR TITLE
refactor: Discordのコマンドハンドラをリファクタリング

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,6 +28,7 @@
 		"drizzle-orm": "0.43.1",
 		"hono": "4.7.8",
 		"neverthrow": "8.2.0",
+		"ts-pattern": "5.7.0",
 		"zod": "3.24.3"
 	},
 	"devDependencies": {

--- a/packages/api/src/__tests__/discord.test.ts
+++ b/packages/api/src/__tests__/discord.test.ts
@@ -1,0 +1,193 @@
+import type {
+	APIApplicationCommandInteractionDataOption,
+	APIChatInputApplicationCommandInteractionData,
+} from "discord-api-types/v10";
+import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { describe, expect, it } from "vitest";
+
+import { parseCommand } from "../discord";
+
+// 完全なテスト用インターフェースを作成
+interface MockInteractionData {
+	name: string;
+	options?: APIApplicationCommandInteractionDataOption[];
+}
+
+// 型安全なモック関数
+function createMockInteraction(
+	mockData: MockInteractionData,
+): APIChatInputApplicationCommandInteractionData {
+	const data: Partial<APIChatInputApplicationCommandInteractionData> = {
+		id: "test-id",
+		name: mockData.name,
+		type: 1,
+		options: mockData.options,
+	};
+
+	return data as APIChatInputApplicationCommandInteractionData;
+}
+
+describe("parseCommand", () => {
+	it("単純なコマンドを正しくパースできること", () => {
+		const interaction = createMockInteraction({
+			name: "test",
+			options: [],
+		});
+
+		const result = parseCommand(interaction);
+		expect(result).toEqual({
+			commands: ["test"],
+			options: {},
+		});
+	});
+
+	it("オプション付きのコマンドを正しくパースできること", () => {
+		const interaction = createMockInteraction({
+			name: "test",
+			options: [
+				{
+					name: "option1",
+					type: ApplicationCommandOptionType.String,
+					value: "value1",
+				},
+				{
+					name: "option2",
+					type: ApplicationCommandOptionType.Integer,
+					value: 42,
+				},
+				{
+					name: "option3",
+					type: ApplicationCommandOptionType.Boolean,
+					value: true,
+				},
+			],
+		});
+
+		const result = parseCommand(interaction);
+		expect(result).toEqual({
+			commands: ["test"],
+			options: {
+				option1: "value1",
+				option2: 42,
+				option3: true,
+			},
+		});
+	});
+
+	it("サブコマンドを正しくパースできること", () => {
+		const interaction = createMockInteraction({
+			name: "test",
+			options: [
+				{
+					name: "subcommand",
+					type: ApplicationCommandOptionType.Subcommand,
+					options: [
+						{
+							name: "option1",
+							type: ApplicationCommandOptionType.String,
+							value: "value1",
+						},
+					],
+				},
+			],
+		});
+
+		const result = parseCommand(interaction);
+		expect(result).toEqual({
+			commands: ["test", "subcommand"],
+			options: {
+				option1: "value1",
+			},
+		});
+	});
+
+	it("サブコマンドグループを正しくパースできること", () => {
+		const interaction = createMockInteraction({
+			name: "test",
+			options: [
+				{
+					name: "group",
+					type: ApplicationCommandOptionType.SubcommandGroup,
+					options: [
+						{
+							name: "subcommand",
+							type: ApplicationCommandOptionType.Subcommand,
+							options: [
+								{
+									name: "option1",
+									type: ApplicationCommandOptionType.String,
+									value: "value1",
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		const result = parseCommand(interaction);
+		expect(result).toEqual({
+			commands: ["test", "group", "subcommand"],
+			options: {
+				option1: "value1",
+			},
+		});
+	});
+
+	it("複雑なネストされた構造を正しくパースできること", () => {
+		const interaction = createMockInteraction({
+			name: "user",
+			options: [
+				{
+					name: "manage",
+					type: ApplicationCommandOptionType.SubcommandGroup,
+					options: [
+						{
+							name: "add",
+							type: ApplicationCommandOptionType.Subcommand,
+							options: [
+								{
+									name: "name",
+									type: ApplicationCommandOptionType.String,
+									value: "山田太郎",
+								},
+								{
+									name: "age",
+									type: ApplicationCommandOptionType.Integer,
+									value: 25,
+								},
+								{
+									name: "is_admin",
+									type: ApplicationCommandOptionType.Boolean,
+									value: false,
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		const result = parseCommand(interaction);
+		expect(result).toEqual({
+			commands: ["user", "manage", "add"],
+			options: {
+				name: "山田太郎",
+				age: 25,
+				is_admin: false,
+			},
+		});
+	});
+
+	it("オプションがない場合も正しく処理できること", () => {
+		const interaction = createMockInteraction({
+			name: "ping",
+		});
+
+		const result = parseCommand(interaction);
+		expect(result).toEqual({
+			commands: ["ping"],
+			options: {},
+		});
+	});
+});

--- a/packages/api/src/handlers/slash-command/index.ts
+++ b/packages/api/src/handlers/slash-command/index.ts
@@ -47,7 +47,7 @@ const NOT_IMPLEMENTED: APIInteractionResponse = {
 	},
 };
 
-function notHandled(dataJSON: string): APIInteractionResponse {
+function handleUnknownCommand(dataJSON: string): APIInteractionResponse {
 	return {
 		type: InteractionResponseType.ChannelMessageWithSource,
 		data: {
@@ -107,7 +107,9 @@ export async function handleSlashCommand(
 			},
 			() => NOT_IMPLEMENTED,
 		)
-		.with(P._, () => notHandled(JSON.stringify(interaction.data, null, 2)))
+		.with(P._, () =>
+			handleUnknownCommand(JSON.stringify(interaction.data, null, 2)),
+		)
 		.exhaustive();
 
 	return await response;

--- a/packages/api/src/handlers/slash-command/index.ts
+++ b/packages/api/src/handlers/slash-command/index.ts
@@ -2,22 +2,19 @@ import type {
 	APIChatInputApplicationCommandInteraction,
 	APIInteractionResponse,
 } from "discord-api-types/v10";
-import {
-	ApplicationCommandOptionType,
-	InteractionResponseType,
-	MessageFlags,
-} from "discord-api-types/v10";
+import { InteractionResponseType, MessageFlags } from "discord-api-types/v10";
 import { HTTPException } from "hono/http-exception";
-import { z } from "zod";
+import { match, P } from "ts-pattern";
 
-import { convertMessageToEmbed } from "@/discord";
+import { convertMessageToEmbed, parseCommand } from "@/discord";
 import type { UseCases } from "@/usecase";
 
 import { ListUsersHandler } from "./list-users";
+import { PingHandler } from "./ping";
 import { RegisterNfcCardHandler } from "./register-nfc-card";
 import { RegisterStudentCardHandler } from "./register-student-card";
-
 export interface SlashCommandHandlers {
+	ping: PingHandler;
 	listUsers: ListUsersHandler;
 	registerStudentCard: RegisterStudentCardHandler;
 	registerNfcCard: RegisterNfcCardHandler;
@@ -27,6 +24,7 @@ export function createSlashCommandHandlers(
 	usecases: UseCases,
 ): SlashCommandHandlers {
 	return {
+		ping: new PingHandler(),
 		listUsers: new ListUsersHandler(usecases.listEntryUsers),
 		registerStudentCard: new RegisterStudentCardHandler(
 			usecases.registerStudentCard,
@@ -35,172 +33,82 @@ export function createSlashCommandHandlers(
 	};
 }
 
-export const SlashCommandSchema = z.union([
-	z.object({
-		name: z.literal("room"),
-		options: z
-			.union([
-				z.object({
-					type: z.literal(ApplicationCommandOptionType.SubcommandGroup),
-					name: z.literal("register"),
-					options: z
-						.union([
-							z.object({
-								type: z.literal(ApplicationCommandOptionType.Subcommand),
-								name: z.literal("student-card"),
-								options: z
-									.object({
-										type: z.literal(ApplicationCommandOptionType.Integer),
-										name: z.literal("id"),
-										value: z.number(),
-									})
-									.array(),
-							}),
-							z.object({
-								type: z.literal(ApplicationCommandOptionType.Subcommand),
-								name: z.literal("nfc-card"),
-								options: z
-									.union([
-										z.object({
-											type: z.literal(ApplicationCommandOptionType.String),
-											name: z.literal("code"),
-											value: z.string(),
-										}),
-										z.object({
-											type: z.literal(ApplicationCommandOptionType.String),
-											name: z.literal("name"),
-											value: z.string(),
-										}),
-									])
-									.array(),
-							}),
-						])
-						.array(),
-				}),
-				z.object({
-					type: z.literal(ApplicationCommandOptionType.Subcommand),
-					name: z.literal("list"),
-				}),
-			])
-			.array(),
-	}),
-	z.object({
-		name: z.literal("room-admin"),
-		options: z
-			.object({
-				type: z.literal(ApplicationCommandOptionType.SubcommandGroup),
-				name: z.literal("setting"),
-				options: z
-					.object({
-						type: z.literal(ApplicationCommandOptionType.Subcommand),
-						name: z.literal("register"),
-						options: z
-							.object({
-								type: z.literal(ApplicationCommandOptionType.Boolean),
-								name: z.literal("allow"),
-								value: z.boolean(),
-							})
-							.array(),
-					})
-					.array(),
-			})
-			.array(),
-	}),
-	z.object({
-		name: z.literal("ping"),
-	}),
-]);
+const NOT_IMPLEMENTED: APIInteractionResponse = {
+	type: InteractionResponseType.ChannelMessageWithSource,
+	data: {
+		embeds: [
+			convertMessageToEmbed({
+				title: "エラー",
+				description: "このコマンドは未実装です。",
+				color: "red",
+			}),
+		],
+		flags: MessageFlags.Ephemeral,
+	},
+};
 
-// eslint-disable-next-line complexity
-export async function handleSlashCommand(
-	handlers: SlashCommandHandlers,
-	interaction: APIChatInputApplicationCommandInteraction,
-): Promise<APIInteractionResponse> {
-	const notImplemented: APIInteractionResponse = {
+function notHandled(dataJSON: string): APIInteractionResponse {
+	return {
 		type: InteractionResponseType.ChannelMessageWithSource,
 		data: {
 			embeds: [
 				convertMessageToEmbed({
 					title: "エラー",
-					description: "このコマンドは未実装です。",
+					description: `未知のコマンドです。不具合の可能性が高いため、開発者にお問い合わせください。\n\n該当のJSON:\n\`\`\`json\n${dataJSON}\`\`\``,
 					color: "red",
 				}),
 			],
 			flags: MessageFlags.Ephemeral,
 		},
 	};
-	const invalidRequestError = new HTTPException(400, {
-		message: "Invalid request",
-	});
+}
 
-	const slashCommand = SlashCommandSchema.safeParse(interaction.data);
-	if (!slashCommand.success) {
-		throw invalidRequestError;
+export async function handleSlashCommand(
+	handlers: SlashCommandHandlers,
+	interaction: APIChatInputApplicationCommandInteraction,
+): Promise<APIInteractionResponse> {
+	const member = interaction.member;
+	if (!member) {
+		throw new HTTPException(400, { message: "Invalid request" });
 	}
 
-	switch (slashCommand.data.name) {
-		case "room": {
-			const option1 = slashCommand.data.options[0];
-			switch (option1?.name) {
-				case "register": {
-					const option2 = option1.options[0];
-					switch (option2?.name) {
-						case "student-card": {
-							const discordId = interaction.member?.user.id;
-							const studentId = option2.options[0]?.value;
-							if (discordId === undefined || studentId === undefined) {
-								throw invalidRequestError;
-							}
+	const discordId = member.user.id;
+	const result = parseCommand(interaction.data);
 
-							return await handlers.registerStudentCard.handle(
-								discordId,
-								studentId,
-							);
-						}
-						case "nfc-card": {
-							const discordId = interaction.member?.user.id;
-							const code = option2.options.find(
-								(o) => o.name === "code",
-							)?.value;
-							const name = option2.options.find(
-								(o) => o.name === "name",
-							)?.value;
+	const response = match(result)
+		.with(
+			{ commands: ["ping"] },
+			(): APIInteractionResponse => handlers.ping.handle(),
+		)
+		.with(
+			{
+				commands: ["room", "register", "student-card"],
+				options: P.select({ id: P.number }),
+			},
+			async ({ id }) =>
+				await handlers.registerStudentCard.handle(discordId, id),
+		)
+		.with(
+			{
+				commands: ["room", "register", "nfc-card"],
+				options: P.select({ code: P.string, name: P.string }),
+			},
+			async ({ code, name }) =>
+				await handlers.registerNfcCard.handle(discordId, code, name),
+		)
+		.with(
+			{ commands: ["room", "list"] },
+			async () => await handlers.listUsers.handle(),
+		)
+		.with(
+			{
+				commands: ["room-admin", "setting", "register"],
+				options: P.select({ allow: P.boolean.optional() }),
+			},
+			() => NOT_IMPLEMENTED,
+		)
+		.with(P._, () => notHandled(JSON.stringify(interaction.data, null, 2)))
+		.exhaustive();
 
-							if (
-								discordId === undefined ||
-								code === undefined ||
-								name === undefined
-							) {
-								throw invalidRequestError;
-							}
-
-							return await handlers.registerNfcCard.handle(
-								discordId,
-								code,
-								name,
-							);
-						}
-					}
-					throw invalidRequestError;
-				}
-				case "list":
-					return await handlers.listUsers.handle();
-				default:
-					throw invalidRequestError;
-			}
-		}
-		case "room-admin":
-			return notImplemented;
-		case "ping":
-			return {
-				type: InteractionResponseType.ChannelMessageWithSource,
-				data: {
-					content: "pong!",
-					flags: MessageFlags.Ephemeral,
-				},
-			};
-		default:
-			slashCommand.data satisfies never;
-			throw invalidRequestError;
-	}
+	return await response;
 }

--- a/packages/api/src/handlers/slash-command/ping.ts
+++ b/packages/api/src/handlers/slash-command/ping.ts
@@ -1,0 +1,13 @@
+import type { APIInteractionResponse } from "discord-api-types/v10";
+import { InteractionResponseType } from "discord-api-types/v10";
+
+export class PingHandler {
+	handle(): APIInteractionResponse {
+		return {
+			type: InteractionResponseType.ChannelMessageWithSource,
+			data: {
+				content: "pong",
+			},
+		};
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       neverthrow:
         specifier: 8.2.0
         version: 8.2.0
+      ts-pattern:
+        specifier: 5.7.0
+        version: 5.7.0
       zod:
         specifier: 3.24.3
         version: 3.24.3
@@ -3045,6 +3048,9 @@ packages:
 
   ts-mixer@6.0.4:
     resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
+  ts-pattern@5.7.0:
+    resolution: {integrity: sha512-0/FvIG4g3kNkYgbNwBBW5pZBkfpeYQnH+2AA3xmjkCAit/DSDPKmgwC3fKof4oYUq6gupClVOJlFl+939VRBMg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -6433,6 +6439,8 @@ snapshots:
   ts-dedent@2.2.0: {}
 
   ts-mixer@6.0.4: {}
+
+  ts-pattern@5.7.0: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
This pull request introduces a new utility for parsing Discord slash commands, refactors the existing slash command handling system for improved maintainability, and adds a new dependency, `ts-pattern`, for pattern matching. The most significant changes include the implementation of the `parseCommand` utility, the replacement of the schema-based command validation with pattern matching, and the addition of a new `PingHandler` for the "ping" command.

### Command Parsing and Handling Improvements:
* Added a new `parseCommand` utility to recursively parse Discord slash command data, supporting subcommands, subcommand groups, and nested options (`packages/api/src/discord.ts`).
* Replaced the schema-based validation of slash commands with `ts-pattern` for pattern matching, simplifying the `handleSlashCommand` logic and improving extensibility (`packages/api/src/handlers/slash-command/index.ts`).

### New Feature:
* Introduced a `PingHandler` class to handle the "ping" slash command, responding with "pong" (`packages/api/src/handlers/slash-command/ping.ts`).

### Dependency Updates:
* Added `ts-pattern` version 5.7.0 as a new dependency for pattern matching (`packages/api/package.json`, `pnpm-lock.yaml`). [[1]](diffhunk://#diff-069a572372e4f2574eb68db90e3d6ff4d0766296abec7b3c7b0f45b098d38fcaR31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR59-R61)

### Testing Enhancements:
* Added comprehensive tests for the `parseCommand` utility to ensure correct parsing of various command structures, including nested subcommands and options (`packages/api/src/__tests__/discord.test.ts`).