### PR TITLE
fix: 未登録NFCカードのメッセージに含まれるコマンドメンション形式を修正

### DIFF
--- a/packages/api/src/handlers/local-device/touch-card.ts
+++ b/packages/api/src/handlers/local-device/touch-card.ts
@@ -127,7 +127,7 @@ export class TouchCardHandler implements LocalDeviceHandler {
 				case "NFC_CARD_NOT_REGISTERED":
 					return {
 						title: "登録されていないNFCカードです",
-						description: `</room register nfc-card ${error.meta.unknownNfcCard.code}:${this.env.DISCORD_ROOM_COMMAND_ID}>でNFCカードを登録してください。`,
+						description: `</room register nfc-card:${this.env.DISCORD_ROOM_COMMAND_ID}>で\`${error.meta.unknownNfcCard.code}\`を使用してNFCカードを登録してください。`,
 						color: colorToHex("red"),
 					};
 				case "UNKNOWN":


### PR DESCRIPTION
This pull request updates the error message formatting in the `TouchCardHandler` class to improve clarity and user experience.

### Error message improvement:
* Modified the `description` field for the `NFC_CARD_NOT_REGISTERED` case to reformat the command syntax and emphasize the NFC card code by wrapping it in backticks. This change enhances the readability and usability of the error message. (`packages/api/src/handlers/local-device/touch-card.ts`, [packages/api/src/handlers/local-device/touch-card.tsL130-R130](diffhunk://#diff-97f9beffce972cec5a433d88035bd0666f78c6d73b08478f60399001a667543aL130-R130))