### PR TITLE
feat: 複数のNFCカードリーダーに対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +477,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,9 +500,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1260,7 +1295,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1408,8 +1443,10 @@ name = "room-manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "chrono",
  "clap",
+ "futures-util",
  "if_chain",
  "mockall",
  "pasori",
@@ -2152,7 +2189,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -28,6 +28,8 @@ chrono = "0.4.40"
 thiserror = "1.0.57"
 if_chain = "1.0.2"
 clap = { version = "4.5.37", features = ["derive", "env"] }
+futures-util = "0.3.31"
+async-stream = "0.3.6"
 
 [dev-dependencies]
 mockall = "0.12.1"

--- a/crates/app/src/domain/mod.rs
+++ b/crates/app/src/domain/mod.rs
@@ -1,9 +1,5 @@
 pub mod entities;
 
-pub trait CardReader {
-    async fn next(&mut self) -> anyhow::Result<Option<Card>>;
-}
-
 pub trait CardApi {
     async fn touch(&self, req: TouchCardRequest) -> anyhow::Result<TouchCardResponse>;
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -16,7 +16,7 @@ use infra::{HttpCardApi, PasoriReader, RodioPlayer, SystemClock};
 use pasori::rusb::{Context as RusbContext, UsbContext};
 use tracing::{error, info, warn};
 
-const VENDER_ID: u16 = 0x054c;
+const VENDOR_ID: u16 = 0x054c;
 const PRODUCT_ID: u16 = 0x06c3;
 
 #[tokio::main]
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
                 return false;
             };
 
-            dev_desc.vendor_id() == VENDER_ID && dev_desc.product_id() == PRODUCT_ID
+            dev_desc.vendor_id() == VENDOR_ID && dev_desc.product_id() == PRODUCT_ID
         })
         .map(|dev| PasoriReader::spawn(dev).map(|reader| reader.into_stream().boxed()))
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/pasori/src/lib.rs
+++ b/crates/pasori/src/lib.rs
@@ -2,3 +2,5 @@
 pub mod device;
 pub mod felica;
 pub mod transport;
+
+pub use rusb;

--- a/crates/pasori/src/main.rs
+++ b/crates/pasori/src/main.rs
@@ -2,11 +2,11 @@ use pasori::device::{Bitrate, Device, rcs380::RCS380};
 use pasori::felica::{BlockCode, PollingRequestCode, PollingTimeSlot, ServiceCode};
 use pasori::transport::Usb;
 
-const VENDER_ID: u16 = 0x054c;
+const VENDOR_ID: u16 = 0x054c;
 const PRODUCT_ID: u16 = 0x06c3;
 
 fn main() -> anyhow::Result<()> {
-    let transport = Usb::from_id(VENDER_ID, PRODUCT_ID)?;
+    let transport = Usb::from_id(VENDOR_ID, PRODUCT_ID)?;
 
     let device = RCS380::new(transport)?;
 

--- a/crates/pasori/src/transport.rs
+++ b/crates/pasori/src/transport.rs
@@ -78,7 +78,7 @@ impl Usb {
         })
     }
 
-    pub fn from_id(vender_id: u16, product_id: u16) -> anyhow::Result<Self> {
+    pub fn from_id(vendor_id: u16, product_id: u16) -> anyhow::Result<Self> {
         let context = Context::new()?;
 
         let dev = context
@@ -89,7 +89,7 @@ impl Usb {
                     return false;
                 };
 
-                dev_desc.vendor_id() == vender_id && dev_desc.product_id() == product_id
+                dev_desc.vendor_id() == vendor_id && dev_desc.product_id() == product_id
             })
             .context("device not found")?;
 


### PR DESCRIPTION
## 概要

このプルリクエストは、アプリケーションが複数の Pasori NFC カードリーダーを同時に認識し、利用できるようにするための機能追加です。これにより、複数のリーダーが接続されている環境でも、いずれかのリーダーでカードがスキャンされた際にイベントを処理できるようになります。

## 変更点

- **複数の Pasori リーダーのサポート:**
    - アプリケーション起動時に、システムに接続されている全ての Pasori リーダー (Vendor ID: `0x054c`, Product ID: `0x06c3`) を検出し、それぞれに対して `PasoriReader` インスタンスを生成するように変更しました。
    - `rusb` ライブラリを使用してデバイスを列挙し、`PasoriReader::spawn` に `rusb::Device` を渡すように変更しました。
    - `pasori` クレートに `rusb` を re-export するように変更しました。(`pasori::rusb`)
    - `pasori::transport::Usb` に `from_device` メソッドを追加し、特定の `rusb::Device` から Transport を作成できるようにしました。
- **`PasoriReader` の Stream 化:**
    - `PasoriReader` に `async-stream` を利用した `into_stream` メソッドを追加しました。これにより、各リーダーからのカードスキャンイベントを非同期ストリームとして扱えるようになりました。
    - `main.rs` では、`futures_util::stream::select_all` を使用して、複数のリーダーからのストリームを単一のストリームにマージし、イベントを処理するように変更しました。
- **リファクタリング:**
    - `crates/app/src/domain/mod.rs` から不要になった `CardReader` トレイトを削除しました。

## レビューしてほしいこと

- 複数のリーダーが接続されている環境での動作確認（もし可能であれば）。
- `PasoriReader` の Stream 化の実装に問題がないか。
- `main.rs` での `select_all` を用いたストリームのマージ処理が適切か。
- `rusb` の使い方やエラーハンドリングに問題がないか。
