### PR TITLE
ci: ワークフローを分割

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,9 @@ jobs:
 
       - name: Run | Build
         run: cross build --release --locked
+
+      - name: Upload | Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: room-manager
+          path: target/aarch64-unknown-linux-gnu/release/room-manager

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build_node:
+    name: Build (Node.js)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup | Node.js development environment
+        uses: ./.github/actions/setup-node
+
+      - name: Run | Build
+        run: pnpm run -r build
+
+  build_rust:
+    name: Build (Rust)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup | Rust development environment
+        uses: ./.github/actions/setup-rust
+
+      - name: Run | Build
+        run: cross build --release --locked

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,31 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  build_node:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup | Node.js development environment
-        uses: ./.github/actions/setup-node
-
-      - name: Run | Build
-        run: pnpm run -r build
-
-  build_rust:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup | Rust development environment
-        uses: ./.github/actions/setup-rust
-
-      - name: Run | Build
-        run: cross build --release --locked
-
   typecheck_node:
+    name: Typecheck (Node.js)
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
@@ -46,6 +23,7 @@ jobs:
         run: pnpm run -r typecheck
 
   lint_node:
+    name: Lint (Node.js)
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
@@ -58,6 +36,7 @@ jobs:
         run: pnpm run -r lint
 
   lint_rust:
+    name: Lint (Rust)
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
@@ -70,6 +49,7 @@ jobs:
         run: cross clippy --all-targets --all-features -- -D warnings
 
   format_node:
+    name: Format (Node.js)
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
@@ -82,6 +62,7 @@ jobs:
         run: pnpm run -r format:check
 
   format_rust:
+    name: Format (Rust)
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
@@ -92,27 +73,3 @@ jobs:
 
       - name: Run | Format
         run: cargo fmt --all -- --check
-
-  test_node:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup | Node.js development environment
-        uses: ./.github/actions/setup-node
-
-      - name: Run | Test
-        run: pnpm run -r test
-
-  test_rust:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup | Rust development environment
-        uses: ./.github/actions/setup-rust
-
-      - name: Run | Test
-        run: cross test --all-targets --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,8 @@ jobs:
       - name: Run | Build
         run: cross build --release --locked
 
-      - name: Run | Compress
-        run: |
-          tar czvf \
-            room-manager-aarch64-unknown-linux-gnu.tar.gz \
-            target/aarch64-unknown-linux-gnu/release/room-manager \
-            README.md
-
       - name: Run | Upload
-        run: gh release upload ${{ inputs.tag_name }} room-manager-aarch64-unknown-linux-gnu.tar.gz
+        run: gh release upload ${{ inputs.tag_name }} target/aarch64-unknown-linux-gnu/release/room-manager
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test_node:
+    name: Test (Node.js)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup | Node.js development environment
+        uses: ./.github/actions/setup-node
+
+      - name: Run | Test
+        run: pnpm run -r test
+
+  test_rust:
+    name: Test (Rust)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup | Rust development environment
+        uses: ./.github/actions/setup-rust
+
+      - name: Run | Test
+        run: cross test --all-targets --all-features


### PR DESCRIPTION
This pull request restructures the GitHub Actions workflows by splitting the build and test jobs into separate files, improving maintainability and clarity. Additionally, it removes redundant steps and updates job naming conventions for better readability.

### Workflow Restructuring:

* Added a new `build.yml` workflow to handle Node.js and Rust build jobs separately, including artifact upload for Rust builds. (`.github/workflows/build.yml`)
* Introduced a new `test.yml` workflow to manage Node.js and Rust test jobs independently. (`.github/workflows/test.yml`)

### Workflow Simplification:

* Removed build and test jobs from the `check.yml` workflow, leaving only typechecking, linting, and formatting jobs. (`.github/workflows/check.yml`) [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L12-R13) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L95-L118)
* Eliminated the compression step in the `release.yml` workflow, simplifying the artifact upload process. (`.github/workflows/release.yml`)

### Naming and Clarity Improvements:

* Updated job names in `check.yml` for better clarity, e.g., "Typecheck (Node.js)", "Lint (Rust)", and "Format (Node.js)". (`.github/workflows/check.yml`) [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R26) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R39) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R52) [[4]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R65)