### PR TITLE
fix: DBスキーマの修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Setup | Node.js development environment
         uses: ./.github/actions/setup-node
 
+      - name: Run | Migrate
+        run: pnpm run ci:migrate
+        working-directory: packages/api
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
       - name: Run | Deploy
         run: pnpm run ci:deploy
         working-directory: packages/api

--- a/packages/api/drizzle/0001_nice_sunfire.sql
+++ b/packages/api/drizzle/0001_nice_sunfire.sql
@@ -1,0 +1,1 @@
+DROP INDEX `nfc_cards_user_id_unique`;

--- a/packages/api/drizzle/meta/0001_snapshot.json
+++ b/packages/api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,388 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "85f379e9-f540-4e6f-b232-249ef5d8862b",
+  "prevId": "3e80dbbc-c178-4c2a-aac2-c4bfd3181131",
+  "tables": {
+    "nfc_cards": {
+      "name": "nfc_cards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idm": {
+          "name": "idm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "nfc_cards_idm_unique": {
+          "name": "nfc_cards_idm_unique",
+          "columns": [
+            "idm"
+          ],
+          "isUnique": true
+        },
+        "idx_nfc_cards_idm": {
+          "name": "idx_nfc_cards_idm",
+          "columns": [
+            "idm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nfc_cards_user_id_users_id_fk": {
+          "name": "nfc_cards_user_id_users_id_fk",
+          "tableFrom": "nfc_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "room_entry_logs": {
+      "name": "room_entry_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "entry_at": {
+          "name": "entry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_at": {
+          "name": "exit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_room_entry_logs_user_id": {
+          "name": "idx_room_entry_logs_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_room_entry_logs_entry_at": {
+          "name": "idx_room_entry_logs_entry_at",
+          "columns": [
+            "entry_at"
+          ],
+          "isUnique": false
+        },
+        "idx_room_entry_logs_exit_at": {
+          "name": "idx_room_entry_logs_exit_at",
+          "columns": [
+            "exit_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "room_entry_logs_user_id_users_id_fk": {
+          "name": "room_entry_logs_user_id_users_id_fk",
+          "tableFrom": "room_entry_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "student_cards": {
+      "name": "student_cards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "student_cards_student_id_unique": {
+          "name": "student_cards_student_id_unique",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": true
+        },
+        "student_cards_user_id_unique": {
+          "name": "student_cards_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_student_cards_student_id": {
+          "name": "idx_student_cards_student_id",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "student_cards_user_id_users_id_fk": {
+          "name": "student_cards_user_id_users_id_fk",
+          "tableFrom": "student_cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "unknown_nfc_cards": {
+      "name": "unknown_nfc_cards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idm": {
+          "name": "idm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unknown_nfc_cards_code_unique": {
+          "name": "unknown_nfc_cards_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "unknown_nfc_cards_idm_unique": {
+          "name": "unknown_nfc_cards_idm_unique",
+          "columns": [
+            "idm"
+          ],
+          "isUnique": true
+        },
+        "idx_unknown_nfc_cards_idm": {
+          "name": "idx_unknown_nfc_cards_idm",
+          "columns": [
+            "idm"
+          ],
+          "isUnique": false
+        },
+        "idx_unknown_nfc_cards_code": {
+          "name": "idx_unknown_nfc_cards_code",
+          "columns": [
+            "code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "columns": [
+            "discord_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1745601795983,
       "tag": "0000_typical_tattoo",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1747153030797,
+      "tag": "0001_nice_sunfire",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -65,7 +65,6 @@ export const nfcCards = sqliteTable(
 		idm: text("idm").notNull().unique(),
 		userId: integer("user_id")
 			.notNull()
-			.unique()
 			.references(() => users.id, { onDelete: "cascade", onUpdate: "cascade" }),
 
 		// timestamps

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -19,6 +19,12 @@ export const users = sqliteTable("users", {
 		.$onUpdateFn(() => Temporal.Now.instant().epochMilliseconds),
 });
 
+export const usersRelations = relations(users, ({ many }) => ({
+	studentCards: many(studentCards),
+	nfcCards: many(nfcCards),
+	roomEntryLogs: many(roomEntryLogs),
+}));
+
 export const studentCards = sqliteTable(
 	"student_cards",
 	{


### PR DESCRIPTION
## 概要

このプルリクエストは、NFCカードのデータベーススキーマを修正し、関連するリレーションを定義するとともに、CIにマイグレーションステップを追加するものです。

## 変更点

- **データベーススキーマの変更:**
    - `nfc_cards` テーブルの `user_id` フィールドからユニーク制約を削除しました。これにより、一人のユーザーが複数のNFCカードを登録できるようになります。
    - `users` テーブルと他のテーブル（`student_cards`, `nfc_cards`, `room_entry_logs`）間に one-to-many のリレーションを定義しました。
- **マイグレーション:**
    - 上記のスキーマ変更に伴うマイグレーションファイル (SQL) を生成しました。
- **CI:**
    - GitHub Actions のリリースワークフローに、デプロイ前のマイグレーション実行ステップを追加しました。
