### PR TITLE
fix: 自動ドアロックの時間を30秒に延長

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pasori"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "if_chain",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "room-manager"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/app/src/infra/gpio_door_lock.rs
+++ b/crates/app/src/infra/gpio_door_lock.rs
@@ -14,7 +14,7 @@ const SERVO_MIN_DUTY_CYCLE: Duration = Duration::from_micros(500);
 const SERVO_MAX_DUTY_CYCLE: Duration = Duration::from_micros(2500);
 
 const SERVO_MOVE_WAIT_TIME: Duration = Duration::from_secs(1);
-const AUTO_LOCK_DELAY: Duration = Duration::from_secs(10);
+const AUTO_LOCK_DELAY: Duration = Duration::from_secs(30);
 
 #[derive(Debug)]
 struct DoorLockInternal {


### PR DESCRIPTION
This pull request updates the auto-lock behavior in the GPIO door lock implementation by extending the delay before the lock automatically engages.

Behavioral Changes:

* [`crates/app/src/infra/gpio_door_lock.rs`](diffhunk://#diff-92448e99ff075d2e3044719cb54909af9986df6a6c53f1cb7be9c103d6596bfdL17-R17): Increased the `AUTO_LOCK_DELAY` from 10 seconds to 30 seconds to provide users with more time before the door automatically locks.