### PR TITLE
Fix README cargo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pnpm install
 
 ```sh
 # Rustアプリケーションの実行（開発モード）
-cargo run -p app
+cargo run -p room-manager
 
 # APIサーバーの開発実行
 cd packages/api
@@ -64,7 +64,7 @@ pnpm dev
 
 ```sh
 # Rustアプリケーションのリリースビルド
-cargo build --release -p app
+cargo build --release -p room-manager
 
 # 実行ファイルは target/release/app に生成されます
 ```


### PR DESCRIPTION
## Summary
- update crate name in README commands

## Testing
- `cargo test` *(fails: can't find crate for core)*
- `pnpm test` in `packages/api` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684070e98900832398e13b9e463c20d4