### PR TITLE
fix: `read_without_encryption`のロジック修正

### DIFF
--- a/crates/pasori/src/device/rcs380.rs
+++ b/crates/pasori/src/device/rcs380.rs
@@ -110,7 +110,7 @@ impl<T: Transport> Device for RCS380<T> {
         }
 
         // ブロック数
-        req.push(service_codes.len() as u8);
+        req.push(block_codes.len() as u8);
         // ブロックコード
         for block_code in block_codes {
             req.extend_from_slice(&block_code.to_bytes());


### PR DESCRIPTION
## Summary
- fix request block count in `read_without_encryption`

## Testing
- `cargo test --target x86_64-unknown-linux-gnu` *(fails: `alsa-sys` build script could not find `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_684070d988688323b8049ede7e64ff52