### PR TITLE
Fix Japanese auto lock delay comment

### DIFF
--- a/crates/app/src/infra/gpio_door_lock.rs
+++ b/crates/app/src/infra/gpio_door_lock.rs
@@ -113,8 +113,8 @@ impl GpioDoorLock {
         {
             let internal = Arc::clone(&internal);
             tokio::spawn(async move {
-                // unlockされたら10秒後にlockする
-                // ただし、10秒以内に別のメッセージが来たらその10秒後にlockをする。
+                // unlockされたら30秒後にlockする
+                // ただし、30秒以内に別のメッセージが来たらその30秒後にlockをする。
                 let mut timer: Option<Pin<Box<Sleep>>> = None;
                 loop {
                     tokio::select! {


### PR DESCRIPTION
## Summary
- fix the Japanese comment in `gpio_door_lock.rs`

## Testing
- `cargo test --target x86_64-unknown-linux-gnu`

------
https://chatgpt.com/codex/tasks/task_e_684070e48c9483238b3de3600df31149